### PR TITLE
updated version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oobe",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Web-based administration portal for conifiguring and upgrading the Edison",
   "main": "src/server.js",
   "dependencies": {


### PR DESCRIPTION
Forgot to bump the version to `1.2.1` for bugfix as per [SemVer](http://semver.org).

Also, realized that this isn't yet in the Edison's Yocto Linux build.  Am I supposed to change `SRCREV` in [`meta-intel-edison/tree/meta-intel-edison-distro/recipes-support/oobe/oobe_1.2.0.bb`](http://git.yoctoproject.org/cgit/cgit.cgi/meta-intel-edison/tree/meta-intel-edison-distro/recipes-support/oobe/oobe_1.2.0.bb) & submit to [`meta-intel@yoctoproject.org` as noted here](http://git.yoctoproject.org/cgit/cgit.cgi/meta-intel-edison/about/)?  Will my tag `v0.2.1` work as a git ref for this?

Thanks in advance!
