### PR TITLE
popen2: Removed unused python import from configure_edison

### DIFF
--- a/src/configure_edison
+++ b/src/configure_edison
@@ -25,7 +25,6 @@ import hashlib
 import argparse
 import json
 import re
-import popen2
 from array import *
 
 WSREGEX = re.compile(r"\s+")


### PR DESCRIPTION
This is a lightweight change.  I'm working on building small images for the
Intel Edison.  I've stripped out everything from the stock IoTDK image for
the edison that's NOT required to run the oobe configure_edison script.
Since popen2 is obsolete (in favor of subprocess) in python > 2.6, popen2
is not used in the configure_edison script, and I'm not including popen2
in my python modules for my smaller builds, it would be helpful to remove
the unused import.

Signed-off-by: Noel Eck noel.eck@intel.com
